### PR TITLE
Bypassing usage of HydroShare API's Python package

### DIFF
--- a/3_process_based_modelling/2c_bow_river_above_banff.ipynb
+++ b/3_process_based_modelling/2c_bow_river_above_banff.ipynb
@@ -90,8 +90,9 @@
    "outputs": [],
    "source": [
     "# modules\n",
-    "import os\n",
     "import time\n",
+    "import requests\n",
+    "import zipfile\n",
     "import subprocess # needed to run mizuRoute.exe from the notebook\n",
     "import numpy as np\n",
     "import xarray as xr\n",
@@ -116,31 +117,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# modules\n",
-    "from hs_restclient import HydroShare # to get the files\n",
-    "import zipfile # and to unzip them"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Make a hydroshare object - note: needs authentication\n",
-    "hs = HydroShare()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Specify the resource ID and download the resource into the main exercise directory\n",
     "resource_id = 'a0cfaa6df18643ccbf777c9e3cdd8a86'\n",
-    "hs.getResource(resource_id, \n",
-    "               destination='.')"
+    "\n",
+    "def download_file(url, destination):\n",
+    "    response = requests.get(url)\n",
+    "    if response.status_code == 200:\n",
+    "        with open(destination, 'wb') as f:\n",
+    "            f.write(response.content)\n",
+    "        print(\"File downloaded successfully.\")\n",
+    "    else:\n",
+    "        print(f\"Failed to download file. Status code: {response.status_code}\")\n",
+    "\n",
+    "# download resource from HydroShare\n",
+    "url = f'https://www.hydroshare.org/hsapi/resource/{resource_id}/'\n",
+    "destination = f'./{resource_id}.zip'\n",
+    "download_file(url, destination)"
    ]
   },
   {
@@ -390,7 +381,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# make the plot\n",
@@ -474,6 +467,50 @@
     "    \n",
     "if not os.path.exists(s_distributed_elev.manager['outputPath'].value):\n",
     "    os.makedirs(s_distributed_elev.manager['outputPath'].value) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "\n",
+    "# keep downloaded files as a backup\n",
+    "directory = \"./output/**/**/*.nc\"\n",
+    "\n",
+    "# list of files\n",
+    "dl_files = glob.glob(directory)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Iterate through files in the directory\n",
+    "for filepath in dl_files:\n",
+    "    filename = filepath.split('/')[-1]\n",
+    "    root_path = '/'.join(filepath.split('/')[0:-1])\n",
+    "    if filename.endswith(\".nc\"):\n",
+    "        # Construct the new filename with _backup suffix\n",
+    "        new_filename = os.path.join(root_path, filename[:-3] + \"_backup.nc\")\n",
+    "        old_filename = os.path.join(root_path, filename)\n",
+    "        \n",
+    "        # Rename the file\n",
+    "        os.rename(old_filename, new_filename)\n",
+    "        print(f\"Renamed {old_filename} to {new_filename}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All `.nc` files downloaded from `HydroShare` is now renamed. This means you can reproduce the files yourself now, while keeping the downlaoded ones as backup."
    ]
   },
   {


### PR DESCRIPTION
Based on a recent conversation with Clara Cogswell, HydroShare team is "working on streamlining [their] API". Therefore, the method to download the resource has been changed to directly use the HTTPS request.

Furthermore, when student would like to run the `2c` simulations themselves, they may face a "Permisison denied" error. To avoid this, another cell is added to assure the downloaded NetCDF file are renamed to have the "_backup" suffix at the end, so student do not face this error, while keeping whatever has been downloaded from HydroShare as a backup. A sentence has been also added to inform students of the renaming procedure.

Reported-by: Martyn Clark <martyn.clark@ucalgary.ca>
Signed-off-by: Kasra Keshavarz <kasra.keshavarz1@ucalgary.ca>