### PR TITLE
Assuring backup files are not included in NetCDF aggregations

### DIFF
--- a/3_process_based_modelling/2c_bow_river_above_banff.ipynb
+++ b/3_process_based_modelling/2c_bow_river_above_banff.ipynb
@@ -554,7 +554,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Initialize a timer\n",
@@ -589,7 +591,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Initialize a timer\n",
@@ -655,7 +659,7 @@
     "# routing post-processing: find the individual annual mizuRoute output files\n",
     "files = []\n",
     "for file in os.listdir(s_distributed.manager['outputPath'].value):\n",
-    "    if 'routed' in file:\n",
+    "    if 'routed.h' in file:\n",
     "        files.append(s_distributed.manager['outputPath'].value + '/' + file)\n",
     "\n",
     "# make sure they are in the right order\n",
@@ -665,7 +669,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# routing post-processing: merge the annual files into a single file\n",
@@ -761,7 +767,7 @@
     "# routing post-processing: find the individual annual mizuRoute output files\n",
     "files = []\n",
     "for file in os.listdir(s_distributed_elev.manager['outputPath'].value):\n",
-    "    if 'routed' in file:\n",
+    "    if 'routed.h' in file:\n",
     "        files.append(s_distributed_elev.manager['outputPath'].value + '/' + file)\n",
     "\n",
     "# make sure they are in the right order\n",


### PR DESCRIPTION
The previous code had an issue where any netCDF file with a "routed" string were being aggregated. This included ones that were "backup". This issue is resolved now, so students can seamlessly execute the notebooks.

Signed-off-by: Kasra Keshavarz <kasra.keshavarz1@ucalgary.ca>